### PR TITLE
Add simple frontend demo for auth endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,10 @@ php artisan serve
 php artisan queue:work
 ```
 
+### Frontend Demo
+Acesse `http://localhost:8000/frontend-demo` para testar rapidamente as rotas de autenticação.
+
+
 ## ⚙️ Configuração do Asaas
 
 ### 1. Obtenha suas credenciais

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -1,1 +1,2 @@
 import './bootstrap';
+import './frontend';

--- a/resources/js/frontend.js
+++ b/resources/js/frontend.js
@@ -1,0 +1,111 @@
+// Simple frontend to interact with auth routes
+const apiUrl = '/api';
+
+function getToken() {
+    return localStorage.getItem('token');
+}
+
+function setToken(token) {
+    localStorage.setItem('token', token);
+    document.getElementById('token-display').textContent = token;
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+    const loginForm = document.getElementById('login-form');
+    const meBtn = document.getElementById('btn-me');
+    const profileForm = document.getElementById('profile-form');
+    const passwordForm = document.getElementById('password-form');
+    const logoutBtn = document.getElementById('logout-btn');
+    const output = document.getElementById('output');
+
+    loginForm.addEventListener('submit', async (e) => {
+        e.preventDefault();
+        const data = {
+            email: loginForm.email.value,
+            password: loginForm.password.value,
+        };
+        const resp = await fetch(`${apiUrl}/auth/login`, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                'Accept': 'application/json',
+            },
+            body: JSON.stringify(data),
+        });
+        const result = await resp.json();
+        if (resp.ok) {
+            setToken(result.data.token);
+            output.textContent = 'Login realizado';
+        } else {
+            output.textContent = result.message || 'Erro no login';
+        }
+    });
+
+    meBtn.addEventListener('click', async () => {
+        const token = getToken();
+        if (!token) return (output.textContent = 'Token não encontrado');
+        const resp = await fetch(`${apiUrl}/auth/me`, {
+            headers: {
+                'Accept': 'application/json',
+                'Authorization': `Bearer ${token}`,
+            },
+        });
+        output.textContent = JSON.stringify(await resp.json(), null, 2);
+    });
+
+    profileForm.addEventListener('submit', async (e) => {
+        e.preventDefault();
+        const token = getToken();
+        if (!token) return (output.textContent = 'Token não encontrado');
+        const data = {
+            name: profileForm.name.value,
+            email: profileForm.email.value,
+            phone: profileForm.phone.value,
+        };
+        const resp = await fetch(`${apiUrl}/auth/profile`, {
+            method: 'PUT',
+            headers: {
+                'Content-Type': 'application/json',
+                'Accept': 'application/json',
+                'Authorization': `Bearer ${token}`,
+            },
+            body: JSON.stringify(data),
+        });
+        output.textContent = JSON.stringify(await resp.json(), null, 2);
+    });
+
+    passwordForm.addEventListener('submit', async (e) => {
+        e.preventDefault();
+        const token = getToken();
+        if (!token) return (output.textContent = 'Token não encontrado');
+        const data = {
+            current_password: passwordForm.current_password.value,
+            password: passwordForm.password.value,
+            password_confirmation: passwordForm.password_confirmation.value,
+        };
+        const resp = await fetch(`${apiUrl}/auth/password`, {
+            method: 'PUT',
+            headers: {
+                'Content-Type': 'application/json',
+                'Accept': 'application/json',
+                'Authorization': `Bearer ${token}`,
+            },
+            body: JSON.stringify(data),
+        });
+        output.textContent = JSON.stringify(await resp.json(), null, 2);
+    });
+
+    logoutBtn.addEventListener('click', async () => {
+        const token = getToken();
+        if (!token) return (output.textContent = 'Token não encontrado');
+        const resp = await fetch(`${apiUrl}/auth/logout`, {
+            method: 'POST',
+            headers: {
+                'Accept': 'application/json',
+                'Authorization': `Bearer ${token}`,
+            },
+        });
+        localStorage.removeItem('token');
+        output.textContent = JSON.stringify(await resp.json(), null, 2);
+    });
+});

--- a/resources/views/frontend.blade.php
+++ b/resources/views/frontend.blade.php
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Frontend Demo</title>
+    @vite(['resources/css/app.css', 'resources/js/app.js'])
+</head>
+<body>
+    <h1>Frontend Demo - Auth Routes</h1>
+
+    <section>
+        <h2>Login</h2>
+        <form id="login-form">
+            <label>Email <input type="email" name="email" required></label><br>
+            <label>Password <input type="password" name="password" required></label><br>
+            <button type="submit">Login</button>
+        </form>
+    </section>
+
+    <section>
+        <h2>Token</h2>
+        <pre id="token-display"></pre>
+    </section>
+
+    <section>
+        <button id="btn-me">Load Me</button>
+    </section>
+
+    <section>
+        <h2>Update Profile</h2>
+        <form id="profile-form">
+            <label>Name <input type="text" name="name" required></label><br>
+            <label>Email <input type="email" name="email" required></label><br>
+            <label>Phone <input type="text" name="phone"></label><br>
+            <button type="submit">Save</button>
+        </form>
+    </section>
+
+    <section>
+        <h2>Change Password</h2>
+        <form id="password-form">
+            <label>Current Password <input type="password" name="current_password" required></label><br>
+            <label>New Password <input type="password" name="password" required></label><br>
+            <label>Confirm Password <input type="password" name="password_confirmation" required></label><br>
+            <button type="submit">Change</button>
+        </form>
+    </section>
+
+    <section>
+        <button id="logout-btn">Logout</button>
+    </section>
+
+    <pre id="output"></pre>
+</body>
+</html>

--- a/routes/web.php
+++ b/routes/web.php
@@ -16,3 +16,5 @@ use Illuminate\Support\Facades\Route;
 Route::get('/', function () {
     return view('welcome');
 });
+
+Route::view("/frontend-demo", "frontend");


### PR DESCRIPTION
## Summary
- add frontend.js with basic fetch logic
- create frontend.blade.php with forms for login, profile, password and logout
- import frontend script in app.js
- expose `/frontend-demo` web route
- document frontend demo in README

## Testing
- `php artisan test` *(fails: vendor directory missing)*

------
https://chatgpt.com/codex/tasks/task_e_6875e21075c0832d9cc5bd4222286bfc